### PR TITLE
fix: start analyzing button loading style

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -156,7 +156,7 @@ export default function Home() {
                 disabled
               >
                 <span>Analyzing </span>
-                <LoadingDots color="white" />
+                <LoadingDots color="grey" />
               </button>
             )}
           </motion.div>


### PR DESCRIPTION
Loading dots disappeared when the button hovered in the loading state for the color of the dots and button background are all white.